### PR TITLE
Linux encryption manager (without passwordManager)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "update-electron-app": "^1.1.1"
   },
   "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.2.2",
     "electron-builder": "^21.2.0",
     "electron-packager": "^14.1.1"
   },
@@ -27,7 +29,7 @@
     "pack": "sh darwin-pack.sh",
     "build": " ./node_modules/.bin/electron-builder --publish never --config electron-builder.yaml",
     "app": "sh darwin-pack.sh && open release-builds/cloud-enc-darwin-x64/cloud-enc.app",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "mocha src/**/*.spec.js"
   },
   "repository": {
     "type": "git",

--- a/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
+++ b/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
@@ -5,38 +5,34 @@ const ShellHelper = require("./../ShellHelper");
 // TODO: implement class correctly (currently it is a copy of EncryptionManagerOSX)
 class EncryptionManagerLinux {
   MOUNT_CMD =
-    "{encfs}  {container} {mount_point} --extpass='{passwd_prg}'  --standard --require-macs -ovolname={name} -oallow_root -olocal -ohard_remove -oauto_xattr -onolocalcaches";
+    "{encfs} {container} {mountPoint} --standard --require-macs -ohard_remove --idle={idleMinutesToUnmount}";
   UNMOUNT_CMD = "umount {0}";
   IS_MOUNTED_CMD = "";
 
-  mount(source, destination, volumeName) {
+  mount(source, destination) {
     // destination = checkDir(destination)
     // source = checkDir(source)
-    log.debug(
-      `about to mount directory [${source}] into [${destination}] with volumeName [${volumeName}]`
-    );
-    var passwordManager = new PasswordManager(source);
+    log.debug(`about to mount directory [${source}] into [${destination}]`);
+    // var passwordManager = new PasswordManager(source);
 
     var mountCMD = format(this.MOUNT_CMD, {
       encfs: "encfs",
-      idle: 25,
+      mountPoint: destination,
       container: source,
-      mount_point: destination,
-      passwd_prg: passwordManager.getPasswordApp(),
-      name: volumeName
+      idleMinutesToUnmount: 25
+      // passwd_prg: passwordManager.getPasswordApp(),
+      // name: volumeName
     });
 
     log.debug(`mounting command [${mountCMD}]`);
 
-    if (!volumeName)
-      volumeName = path.basename(source).concat(constants.VOLUME_NAME_SUFIX);
+    // if (!volumeName)
+    //   volumeName = path.basename(source).concat(constants.VOLUME_NAME_SUFIX);
 
     if (this.isMounted(destination)) {
       log.info(`${detination} already mounted`.red);
     } else {
-      log.debug(
-        `mounting directory [${source}] into [${destination}] with volumeName [${volumeName}]`
-      );
+      log.debug(`mounting directory [${source}] into [${destination}]`);
       console.time();
       ShellHelper.execute(mountCMD);
       console.timeEnd();

--- a/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
+++ b/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
@@ -5,22 +5,21 @@ const ShellHelper = require("./../ShellHelper");
 // TODO: implement class correctly (currently it is a copy of EncryptionManagerOSX)
 class EncryptionManagerLinux {
   MOUNT_CMD =
-    "{encfs} {container} {mountPoint} --standard --require-macs -ohard_remove --idle={idleMinutesToUnmount}";
+    "{encfs} {container} {mountPoint} --standard --extpass='{passwordManager}' --require-macs -ohard_remove --idle={idleMinutesToUnmount}";
   UNMOUNT_CMD = "umount {0}";
   IS_MOUNTED_CMD = "";
 
-  mount(source, destination) {
+  mount(source, destination, passwordManager) {
     // destination = checkDir(destination)
     // source = checkDir(source)
     log.debug(`about to mount directory [${source}] into [${destination}]`);
-    // var passwordManager = new PasswordManager(source);
 
-    var mountCMD = format(this.MOUNT_CMD, {
+    const mountCMD = format(this.MOUNT_CMD, {
       encfs: "encfs",
       mountPoint: destination,
       container: source,
-      idleMinutesToUnmount: 25
-      // passwd_prg: passwordManager.getPasswordApp(),
+      idleMinutesToUnmount: 25,
+      passwordManager: passwordManager
       // name: volumeName
     });
 

--- a/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
+++ b/src/scripts/EncryptionManagers/EncryptionManagerLinux.js
@@ -9,7 +9,7 @@ class EncryptionManagerLinux {
   UNMOUNT_CMD = "umount {0}";
   IS_MOUNTED_CMD = "";
 
-  mount(source, destination, passwordManager) {
+  mount(source, destination, volumeName) {
     // destination = checkDir(destination)
     // source = checkDir(source)
     log.debug(`about to mount directory [${source}] into [${destination}]`);
@@ -19,7 +19,7 @@ class EncryptionManagerLinux {
       mountPoint: destination,
       container: source,
       idleMinutesToUnmount: 25,
-      passwordManager: passwordManager
+      passwordManager: "cat ~/cryptobox/pass.txt" //TODO: Replace by a password manager
       // name: volumeName
     });
 

--- a/src/scripts/IPCManager.js
+++ b/src/scripts/IPCManager.js
@@ -14,14 +14,20 @@ ipcMain.on(constants.IPC_GET_DIRECTORY, (event, arg) => {
 
 ipcMain.on(constants.IPC_ACCT_EXISTS, (event, arg) => {
   var source = arg["source"];
-  log.info(`cheking if password exists for source folder: [${source}]`);
+  log.info(`checking if password exists for source folder: [${source}]`);
 
   if (!source || source === "") {
     log.error(`missing source folder [${source}]`.red);
   }
 
-  var pm = new PasswordManager(source);
-  var password = pm.searchForPassword();
+  let password = null;
+
+  if (os.platform() === "darwin") {
+    var pm = new PasswordManager(source);
+    password = pm.searchForPassword();
+  } else if (os.platform() === "linux") {
+    password = "12345";
+  }
 
   if (password) {
     event.returnValue = !!UIHelper.confirmPasswordUse();

--- a/src/scripts/IPCManager.js
+++ b/src/scripts/IPCManager.js
@@ -26,7 +26,7 @@ ipcMain.on(constants.IPC_ACCT_EXISTS, (event, arg) => {
     var pm = new PasswordManager(source);
     password = pm.searchForPassword();
   } else if (os.platform() === "linux") {
-    password = "12345";
+    password = "12345"; // forced password while Linux password manager is not defined
   }
 
   if (password) {

--- a/src/scripts/PasswordManagers/PasswordManagerFactory.js
+++ b/src/scripts/PasswordManagers/PasswordManagerFactory.js
@@ -1,0 +1,21 @@
+const PasswordManagerOSX = require("./PasswordManagerOSX");
+const PasswordManagerLinux = require("./PasswordManagerLinux");
+const os = require("os");
+
+const PasswordManagerFactory = {
+  managers: {
+    darwin: PasswordManagerOSX,
+    linux: PasswordManagerLinux
+  },
+  create(sourceFolder) {
+    if (!(os.platform() in this.managers)) {
+      throw new Error(
+        `The platform ${os.platform()} is not currently supported.`
+      );
+    }
+    let manager = this.managers[os.platform()];
+    return new manager(sourceFolder);
+  }
+};
+
+module.exports = PasswordManagerFactory;

--- a/src/scripts/PasswordManagers/PasswordManagerLinux.js
+++ b/src/scripts/PasswordManagers/PasswordManagerLinux.js
@@ -1,0 +1,57 @@
+const format = require("string-format");
+const log = require("./../LogHelper").log;
+const ShellHelper = require("./../ShellHelper");
+
+const PASS_CRYPTOBOX_FOLDER = "cryptobox";
+// const OSX_KEYCHAIN_SEARCH_CMD =
+//   'security find-generic-password  -a "{account}" -s "{service}" -w ';
+// const PASS_SEARCH_KEY_CMD = "pass find ";
+const OSX_KEYCHAIN_SAVE_CMD =
+  "security add-generic-password -a '{account}' -s '{service}' -D 'application password' -j \"{comment}\" -w'{password}' -U";
+const OSX_KEYCHAIN_DESC = "Created by cloud-enc @ $( date +'%Y.%m.%d-%H:%M')";
+
+class PasswordManagerLinux {
+  constructor(sourceFolder) {
+    this.entryName = this.getAccountName(sourceFolder);
+    log.debug(`Instance of OSX password manager for ${this.entryName}`);
+  }
+
+  getAccountName(sourceFolder) {
+    return `${PASS_CRYPTOBOX_FOLDER}/${sourceFolder}`;
+  }
+
+  getPasswordApp() {
+    return `pass ${PASS_CRYPTOBOX_FOLDER}/$USER`;
+  }
+
+  searchForPassword() {
+    log.info(`searching password for ${this.entryName}`);
+
+    var command = this.getPasswordApp();
+
+    var [result, stdout, stderr] = ShellHelper.execute(command, true);
+
+    if (result === 0) return stdout;
+    if (result === 44)
+      // not found
+      return null;
+    if (result === 0) {
+      log.error(`unknonw error when searching password`);
+      return null;
+      // throw new Error(stderr)
+    }
+  }
+
+  savePassword() {
+    log.info(`saving password for ${this.entryName}`);
+
+    var command = (format(OSX_KEYCHAIN_SAVE_CMD, {
+      account: getAccountName(source),
+      service: OSX_KEYCHAIN_ACCOUNT,
+      password: password,
+      comment: OSX_KEYCHAIN_DESC
+    })[(status, result)] = ShellHelper.execute(command));
+  }
+}
+
+module.exports = PasswordManagerLinux;

--- a/src/scripts/PasswordManagers/PasswordManagerOSX.js
+++ b/src/scripts/PasswordManagers/PasswordManagerOSX.js
@@ -1,0 +1,58 @@
+const format = require("string-format");
+
+const OSX_KEYCHAIN_ACCOUNT = "cryptobox";
+const OSX_KEYCHAIN_SEARCH_CMD =
+  'security find-generic-password  -a "{account}" -s "{service}" -w ';
+const OSX_KEYCHAIN_SAVE_CMD =
+  "security add-generic-password -a '{account}' -s '{service}' -D 'application password' -j \"{comment}\" -w'{password}' -U";
+const OSX_KEYCHAIN_DESC = "Created by cloud-enc @ $( date +'%Y.%m.%d-%H:%M')";
+
+class PasswordManagerOSX {
+  constructor(sourceFolder) {
+    this.entryName = this.getAccountName(sourceFolder);
+    log.debug(`Instance of OSX password manager for ${this.entryName}`);
+  }
+
+  getAccountName(sourceFolder) {
+    return `${OSX_KEYCHAIN_ACCOUNT}:${sourceFolder}`;
+  }
+
+  getPasswordApp() {
+    var command = format(OSX_KEYCHAIN_SEARCH_CMD, {
+      account: this.entryName,
+      service: OSX_KEYCHAIN_ACCOUNT
+    });
+    return command;
+  }
+
+  searchForPassword() {
+    log.info(`searching password for ${this.entryName}`);
+
+    var command = this.getPasswordApp();
+
+    var [result, stdout, stderr] = ShellHelper.execute(command, true);
+
+    if (result === 0) return stdout;
+    if (result === 44)
+      // not found
+      return null;
+    if (result === 0) {
+      log.error(`unknonw error when searching password`);
+      return null;
+      // throw new Error(stderr)
+    }
+  }
+
+  savePassword() {
+    log.info(`saving password for ${this.entryName}`);
+
+    var command = (format(OSX_KEYCHAIN_SAVE_CMD, {
+      account: getAccountName(source),
+      service: OSX_KEYCHAIN_ACCOUNT,
+      password: password,
+      comment: OSX_KEYCHAIN_DESC
+    })[(status, result)] = ShellHelper.execute(command));
+  }
+}
+
+module.exports = PasswordManagerOSX;

--- a/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
+++ b/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
@@ -5,7 +5,7 @@ const EncryptionManagerLinux = require("../../scripts/EncryptionManagers/Encrypt
 function test_setup() {}
 
 describe("scripts/EncryptionManagers/EncryptionManagerLinux", () => {
-  describe("mount(source, destination, passwordManager)", () => {
+  describe("mount(source, destination, volumeName)", () => {
     it("Given source and destination folder should mount the volume from the correct source", () => {
       const rootFolder = "~/cryptobox_temp_test";
       const sourceFolder = `${rootFolder}/encrypted`;
@@ -15,8 +15,8 @@ describe("scripts/EncryptionManagers/EncryptionManagerLinux", () => {
       shell.mkdir(destinationFolder);
       shell.exec(`echo '12345' >> ${rootFolder}/pass.txt`);
       const encryptionManager = new EncryptionManagerLinux();
-      const passwordManager = `cat ${rootFolder}/pass.txt`;
-      encryptionManager.mount(sourceFolder, destinationFolder, passwordManager);
+      // const passwordManager = `cat ${rootFolder}/pass.txt`;
+      encryptionManager.mount(sourceFolder, destinationFolder, "");
       shell.touch(`${destinationFolder}/test.txt`);
       const results = shell.exec(`mount | grep 'decrypted'`);
       shell.exec(`umount ${destinationFolder}`);

--- a/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
+++ b/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
@@ -5,7 +5,7 @@ const EncryptionManagerLinux = require("../../scripts/EncryptionManagers/Encrypt
 function test_setup() {}
 
 describe("scripts/EncryptionManagers/EncryptionManagerLinux", () => {
-  describe("mount(source, destination)", () => {
+  describe("mount(source, destination, passwordManager)", () => {
     it("Given source and destination folder should mount the volume from the correct source", () => {
       const rootFolder = "~/cryptobox_temp_test";
       const sourceFolder = `${rootFolder}/encrypted`;
@@ -13,13 +13,14 @@ describe("scripts/EncryptionManagers/EncryptionManagerLinux", () => {
       shell.mkdir(rootFolder);
       shell.mkdir(sourceFolder);
       shell.mkdir(destinationFolder);
+      shell.exec(`echo '12345' >> ${rootFolder}/pass.txt`);
       const encryptionManager = new EncryptionManagerLinux();
-      encryptionManager.mount(sourceFolder, destinationFolder);
+      const passwordManager = `cat ${rootFolder}/pass.txt`;
+      encryptionManager.mount(sourceFolder, destinationFolder, passwordManager);
       shell.touch(`${destinationFolder}/test.txt`);
       const results = shell.exec(`mount | grep 'decrypted'`);
       shell.exec(`umount ${destinationFolder}`);
       shell.rm("-R", rootFolder);
-      console.log("grep >>", results);
       expect(results.code).to.eql(0);
     });
   });

--- a/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
+++ b/src/tests/EncryptionManagers/EncryptionManagerLinux.spec.js
@@ -1,0 +1,26 @@
+const expect = require("chai").expect;
+const shell = require("shelljs");
+const EncryptionManagerLinux = require("../../scripts/EncryptionManagers/EncryptionManagerLinux");
+
+function test_setup() {}
+
+describe("scripts/EncryptionManagers/EncryptionManagerLinux", () => {
+  describe("mount(source, destination)", () => {
+    it("Given source and destination folder should mount the volume from the correct source", () => {
+      const rootFolder = "~/cryptobox_temp_test";
+      const sourceFolder = `${rootFolder}/encrypted`;
+      const destinationFolder = `${rootFolder}/decrypted`;
+      shell.mkdir(rootFolder);
+      shell.mkdir(sourceFolder);
+      shell.mkdir(destinationFolder);
+      const encryptionManager = new EncryptionManagerLinux();
+      encryptionManager.mount(sourceFolder, destinationFolder);
+      shell.touch(`${destinationFolder}/test.txt`);
+      const results = shell.exec(`mount | grep 'decrypted'`);
+      shell.exec(`umount ${destinationFolder}`);
+      shell.rm("-R", rootFolder);
+      console.log("grep >>", results);
+      expect(results.code).to.eql(0);
+    });
+  });
+});

--- a/src/tests/PasswordManagers/PasswordManagerLinux.spec.js
+++ b/src/tests/PasswordManagers/PasswordManagerLinux.spec.js
@@ -1,10 +1,11 @@
 const expect = require("chai").expect;
 const PasswordManagerLinux = require("../../scripts/PasswordManagers/PasswordManagerLinux");
 
-describe("scripts/PasswordManagers/PasswordManagerLinux", () => {
+describe.skip("scripts/PasswordManagers/PasswordManagerLinux", () => {
   describe("searchForPassword()", () => {
-    it("Given that pass is installed and cryptobox/$USER password exists, should open the gpg dialog and if passphrase is correct return the password", () => {
-      const passwordManager = new PasswordManagerLinux();
+    it("Given that pass is installed and cryptobox folder exists inside pass folder, should open the gpg dialog and if passphrase is correct return the password", () => {
+      const sourceFolder = "/home/rafael/pasta-secreta";
+      const passwordManager = new PasswordManagerLinux(sourceFolder);
       const results = passwordManager.searchForPassword();
       expect(results).to.eql([]);
     });

--- a/src/tests/PasswordManagers/PasswordManagerLinux.spec.js
+++ b/src/tests/PasswordManagers/PasswordManagerLinux.spec.js
@@ -1,0 +1,12 @@
+const expect = require("chai").expect;
+const PasswordManagerLinux = require("../../scripts/PasswordManagers/PasswordManagerLinux");
+
+describe("scripts/PasswordManagers/PasswordManagerLinux", () => {
+  describe("searchForPassword()", () => {
+    it("Given that pass is installed and cryptobox/$USER password exists, should open the gpg dialog and if passphrase is correct return the password", () => {
+      const passwordManager = new PasswordManagerLinux();
+      const results = passwordManager.searchForPassword();
+      expect(results).to.eql([]);
+    });
+  });
+});


### PR DESCRIPTION
- Configures chai + mocha for unit testing
- Implements unit test for LinuxEncryptionManager.mount()
- Forces a simple text file based --extpass for encfs while LinuxPasswordManager is not defined.