### PR TITLE
prevents filepath with special char. to break

### DIFF
--- a/src/services/encryption/EncryptionServiceLinux.ts
+++ b/src/services/encryption/EncryptionServiceLinux.ts
@@ -11,12 +11,11 @@ export class EncryptionServiceLinux extends EncryptionServiceBase
   getUnmountCMD(volume: Volume): string {
     // return `umount "${volume.decryptedFolderPath}"`;
     return `fusermount -u "${volume.decryptedFolderPath}"`;
-    
   }
 
   getMountCMD(volume: Volume, passwordCommand: string): string {
     let impl = "encfs";
-    return `${impl} ${volume.encryptedFolderPath} ${volume.decryptedFolderPath} --standard --extpass='${passwordCommand}' --require-macs -ohard_remove --idle=${volume.ttl}`;
+    return `${impl} '${volume.encryptedFolderPath}' '${volume.decryptedFolderPath}' --standard --extpass='${passwordCommand}' --require-macs -ohard_remove --idle=${volume.ttl}`;
   }
 }
 


### PR DESCRIPTION
just treats the file paths as strings to build the encfs command. This prevents the mounting to fail in case where the paths have special characters such as accents or space